### PR TITLE
Add missing dependancy & pin fastavro to a compatible version

### DIFF
--- a/faust-project/setup.py
+++ b/faust-project/setup.py
@@ -2,11 +2,12 @@ from setuptools import setup, find_packages
 
 requires = [
     "colorlog>=3.1.4",
-    "fastavro>=0.22.3",
+    "fastavro<=0.22.3",
     "robinhood-aiokafka>=1.0.3",
     "requests>=2.22.0",
     "simple-settings>=0.16.0",
     "python-schema-registry-client[faust]>=1.0.0",
+    "typing-extensions==3.7.4.1",
 ]
 
 setup(


### PR DESCRIPTION
* fastavro is failing with 
```
faust-project_1    | pkg_resources.ContextualVersionConflict: (fastavro 0.22.9 (/usr/local/lib/python3.7/site-packages), Requirement.parse('fastavro<=0.22.3'), {'python-schema-registry-client'})
```
* there's an error caused by missing `typing-extensions` library
```
faust-project_1    | Traceback (most recent call last):
faust-project_1    |   File "/usr/local/bin/example", line 11, in <module>
faust-project_1    |     load_entry_point('faust-example', 'console_scripts', 'example')()
faust-project_1    |   File "/usr/local/lib/python3.7/site-packages/pkg_resources/__init__.py", line 489, in load_entry_point
.......
faust-project_1    |   File "/usr/local/lib/python3.7/site-packages/mode/utils/logging.py", line 48, in <module>
faust-project_1    |     from typing_extensions import Protocol
faust-project_1    | ModuleNotFoundError: No module named 'typing_extensions'
```
